### PR TITLE
Bump termcolor from 2.3 to 2.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "jinja2~=3.1",
     "attrs~=23.2",
     "pypubsub~=4.0",
-    "termcolor~=2.3",
+    "termcolor~=2.4",
 ]
 requires-python = ">=3.9"
 dynamic = ['version', 'description']


### PR DESCRIPTION
Hi,

Is it possible to bump the version of termcolor as the latest release is the 2.4 release in December 2023.