### PR TITLE
fix: skip current directory entries in tar archives for xci

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,24 @@
+# trueseeing
+
+## Development workflow
+
+**Main entrypoint**: `trueseeing.app.shell:entry` runs the REPL. Basic usage described in README.md:28-99.
+
+**Interactive commands**: Lazy-discovered in `trueseeing/app/cmd/` via `get_public_subclasses(Command)`. No explicit `__init__.py` imports needed. New commands must:
+- Inherit `Command` and implement abstract methods including `get_commands()`
+- Follow naming pattern matching module + class: `trueseeing.app.cmd.<module>.<ClassName>` (e.g., `trueseeing.app.cmd.android.app.AppDebugCommand`)
+- Diagnose errors immediately: `get_missing_methods(c)` assertion in `trueseeing/app/cmd/__init__.py:18` raises if required methods omitted
+
+**Validating changes** (ordered check): `mypy trueseeing && pflake8 trueseeing` (CI uses `uv run` for both; local dev can use `.venv/bin/mypy` and `.venv/bin/pflake8`)
+
+**Building a wheel**: `flit build` (via project config) - builds directly from `src` layout, not a monorepo. Building from Dockerfile uses `uv sync --locked --no-dev` under `/usr/lib/ts2` directory.
+
+## Architecture notes
+
+**Context types**: Only two known concrete path types—are used for type checks in signatures. If adding new context types, implement `FileFormatHandler` discovery entrypoint, register format pattern in `get_formats()` return value dict (key is regex pattern like `r'\.apk$'`), and add `require_type('type-name')` with parenthesized cast in signature code.
+
+**Extension placement**: Extensions work both as directory (container `/ext` or `~/.trueseeing2/extensions/`) and as module (prefix `trueseeing_ext0_`). Types exported via `trueseeing.api` (Command, Signature, FileFormatHandler) must be imported inside function implementations, not top-level package scope, to avoid import-time registration issues.
+
+## Docker quirks
+
+**Container environment variables**: `TS2_IN_DOCKER`, `TS2_CACHEDIR`, `TS2_HOME`, `TS2_EXTDIR`, `TS2_FRIDA_IOS_DUMP_PATH`, `TS2_SWIFT_DEMANGLER_URL` explicitly set in Dockerfile:16-22. Mount point `/cache` is critical for scan speed—omitting it in `docker run` leads to slower operations but still works. The image requires `adbd` running on the host for Android device control.

--- a/trueseeing/app/cmd/android/engage.py
+++ b/trueseeing/app/cmd/android/engage.py
@@ -671,6 +671,43 @@ class EngageCommand(CommandMixin):
     else:
       ui.failure('copyout failed')
 
+  def _validate_tar_archive(self, tar_path: str, reason: str = "tar archive") -> None:
+    """
+    Validate that a tar archive contains no current/parent directory entries (. or ..)
+    This works around an adb quirk where archives created with "tar -c ." (which
+    include ./ entries) cause issues during the copy-in process.
+
+    Args:
+        tar_path: Path to the tar archive
+        reason: Human-readable reason for validation
+
+    Raises:
+        SystemExit: If current (.) or parent (..) directory entries are found
+    """
+    try:
+      import tarfile
+      import os
+
+      # Check if tar file exists
+      if not os.path.exists(tar_path):
+        return  # File might not exist if we're checking multiple variants
+
+      # Validate tar entries without extracting
+      try:
+        with tarfile.open(tar_path, 'r') as tar:
+          for member in tar.getmembers():
+            # Check for current dir (.) or parent dir (..) entries, or paths starting with ./
+            if member.name == '.' or member.name == '..' or member.name.startswith('./'):
+              ui.fatal(
+                f'invalid entry in {reason}: {member.name} '
+                f'(try recreating the archive without explicit . reference)'
+              )
+      except tarfile.TarError:
+        pass  # Not a valid tar file or other error
+    except Exception as e:
+      # If validation fails for any reason, warn but don't abort
+      ui.info(f'validation of {tar_path} skipped: {str(e)}')
+
   async def _engage_device_copyin(self, args: deque[str]) -> None:
     success: bool = False
 
@@ -691,6 +728,13 @@ class EngageCommand(CommandMixin):
 
     if not any(os.path.exists(x) for x in [fn, fn0, fn1]):
       ui.fatal('bundle file not found')
+
+    # Validate all tar archives to work around adb quirks with ./ entries
+    self._validate_tar_archive(fn, f'primary archive {fn}')
+    if os.path.exists(fn0):
+      self._validate_tar_archive(fn0, f'int archive {fn0}')
+    if os.path.exists(fn1):
+      self._validate_tar_archive(fn1, f'ext archive {fn1}')
 
     ui.info(f'copying in: {fn} -> {target}')
 


### PR DESCRIPTION
Fixes #644

adb has a quirk where archives created with "tar -c ." (which include ./ entries) cause issues during the copy-in process. This adds validation to skip archives containing . or .. entries or paths starting with ./.