### PR TITLE
Add co (copyout) command for iOS

### DIFF
--- a/trueseeing/app/cmd/android/engage.py
+++ b/trueseeing/app/cmd/android/engage.py
@@ -37,9 +37,9 @@ class EngageCommand(CommandMixin):
       'xtb':dict(e=self._engage_tamper_enable_backup, n='xtb', d='engage: make backupable', t={'apk'}),
       'xtt':dict(e=self._engage_tamper_patch_target_api_level, n='xtt[!] <api level>', d='engage: patch target api level', t={'apk'}),
       'xtt!':dict(e=self._engage_tamper_patch_target_api_level, t={'apk'}),
-      'xco':dict(e=self._engage_device_copyout, n='xco[!] package [data.tar]', d='engage: copy-out package data', t={'apk'}),
+      'xco':dict(e=self._engage_device_copyout, n='xco[!] [package] [data.tar]', d='engage: copy-out package data (package defaults to target)', t={'apk'}),
       'xco!':dict(e=self._engage_device_copyout, t={'apk'}),
-      'xci':dict(e=self._engage_device_copyin, n='xci[!] package [data.tar]', d='engage: copy-in package data', t={'apk'}),
+      'xci':dict(e=self._engage_device_copyin, n='xci[!] [package] [data.tar]', d='engage: copy-in package data (package defaults to target)', t={'apk'}),
       'xci!':dict(e=self._engage_device_copyin, t={'apk'}),
       'xpd':dict(e=self._engage_deploy_package, n='xpd[!]', d='engage: deploy target package', t={'apk'}),
       'xpd!':dict(e=self._engage_deploy_package, t={'apk'}),
@@ -581,10 +581,11 @@ class EngageCommand(CommandMixin):
     success: bool = False
 
     cmd = args.popleft()
-    if not args:
-      ui.fatal('need package name')
-
-    target = args.popleft()
+    if args:
+      target = args.popleft()
+    else:
+      context = self._helper.get_context().require_type('apk')
+      target = context.get_package_name()
 
     import os
     if not args:
@@ -712,20 +713,27 @@ class EngageCommand(CommandMixin):
     success: bool = False
 
     _ = args.popleft()
-    if not args:
-      ui.fatal('need package name')
-
-    target = args.popleft()
-
-    import os
-    if not args:
-      fn = f'{target}.tar'
+    if args:
+      arg0 = args.popleft()
+      # If arg ends with .tar, it's a file; otherwise it's a package name
+      if arg0.endswith('.tar'):
+        target = self._helper.get_context().require_type('apk').get_package_name()
+        fn = arg0
+      else:
+        target = arg0
+        if not args:
+          fn = f'{target}.tar'
+        else:
+          fn = args.popleft()
     else:
-      fn = args.popleft()
+      context = self._helper.get_context().require_type('apk')
+      target = context.get_package_name()
+      fn = f'{target}.tar'
 
     fn0 = fn.replace('.tar', '') + '-int.tar'
     fn1 = fn.replace('.tar', '') + '-ext.tar'
 
+    import os
     if not any(os.path.exists(x) for x in [fn, fn0, fn1]):
       ui.fatal('bundle file not found')
 

--- a/trueseeing/app/cmd/ios/asm.py
+++ b/trueseeing/app/cmd/ios/asm.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+from typing import TYPE_CHECKING
+
+from collections import deque
+
+from trueseeing.core.model.cmd import CommandMixin
+from trueseeing.core.env import is_in_container
+from trueseeing.core.ui import ui
+
+if TYPE_CHECKING:
+  from typing import Any, Optional, Literal, Dict
+  from trueseeing.api import CommandHelper, Command, CommandMap, OptionMap
+
+  ArchiveFormat = Optional[Literal['tar:', 'tar:gz']]
+
+class AssembleCommand(CommandMixin):
+  def __init__(self, helper: CommandHelper) -> None:
+    self._helper = helper
+
+  @staticmethod
+  def create(helper: CommandHelper) -> Command:
+    return AssembleCommand(helper)
+
+  def get_commands(self) -> CommandMap:
+    return {
+      'co':dict(e=self._export_context, n='co[!] /path [pat]', d='export codebase', t={'ipa'}),
+      'co!':dict(e=self._export_context, t={'ipa'}),
+    }
+
+  def get_options(self) -> OptionMap:
+    return dict()
+
+  async def _export_context(self, args: deque[str]) -> None:
+    self._helper.require_target()
+
+    _ = args.popleft()
+
+    if not args:
+      ui.fatal('need path')
+
+    root = args.popleft()
+    ui.info('exporting target to {root}'.format(root=root))
+
+    if args:
+      pat = args.popleft()
+    else:
+      pat = None
+
+    import os
+    import time
+
+    archive = self._deduce_archive_format(root)
+
+    if not archive:
+      self._warn_if_container('exporting to directory could be slow in container builds (try exporting to archives)')
+
+    at = time.time()
+    extracted = 0
+    context = self._helper.get_context()
+    q = context.store().query()
+
+    if not archive:
+      for path,blob in q.file_enum(pat=pat, regex=True):
+        target = os.path.join(root, *path.split('/'))
+        if extracted % 10000 == 0:
+          ui.info(' .. {nr} files'.format(nr=extracted))
+        os.makedirs(os.path.dirname(target), exist_ok=True)
+        with open(target, 'wb') as f:
+          f.write(blob)
+          extracted += 1
+    elif archive.startswith('tar'):
+      import tarfile
+      from io import BytesIO
+      kwargs: Dict[str, int] = dict()
+      subformat = archive[4:]
+
+      if subformat in ['gz']:
+        kwargs.update(dict(compresslevel=3))
+
+      with tarfile.open(root, 'w:{}'.format(subformat), **kwargs) as tf:  # type: ignore[call-overload]
+        now = int(time.time())
+        for path,blob in q.file_enum(pat=pat, regex=True):
+          target = os.path.join('files', *path.split('/'))
+          if extracted % 10000 == 0:
+            ui.info(' .. {nr} files'.format(nr=extracted))
+
+          bf = BytesIO(blob)
+          ti = tarfile.TarInfo(name=target)
+          ti.size = len(blob)
+          ti.uname = 'root'
+          ti.gname = 'root'
+          ti.mode = 0o600
+          ti.mtime = now
+          tf.addfile(ti, fileobj=bf)
+          extracted += 1
+
+    ui.success('done: {nr} files ({t:.02f} sec.)'.format(nr=extracted, t=(time.time() - at)))
+
+  def _deduce_archive_format(self, path: str) -> ArchiveFormat:
+    if path.endswith('.tar'):
+      return 'tar:'
+    elif path.endswith('.tar.gz'):
+      return 'tar:gz'
+    else:
+      return None
+
+  def _warn_if_container(self, *args: Any, **kw: Any) -> None:
+    if is_in_container():
+      ui.warn(*args, **kw)

--- a/trueseeing/core/ios/context.py
+++ b/trueseeing/core/ios/context.py
@@ -82,6 +82,29 @@ class IPAContext(Context):
     else:
       raise KeyError()
 
+  def get_package_name(self) -> str:
+    def _get_manif() -> Optional[Mapping[str, Any]]:
+      import re
+      from zipfile import ZipFile
+      with ZipFile(self._path, 'r') as zf:
+        for i in zf.infolist():
+          if i.is_dir():
+            continue
+          if re.match(r'Payload/.*?.app/Info.plist', i.filename):
+            from plistlib import loads
+            o = loads(zf.read(i))
+            assert isinstance(o, dict)
+            return o
+      return None
+
+    manif = _get_manif()
+    if manif is not None:
+      pkg = manif.get('CFBundleIdentifier')
+      if pkg:
+        assert isinstance(pkg, str)
+        return pkg
+    raise KeyError('CFBundleIdentifier not found')
+
   async def _analyze(self, level: int) -> None:
     q: IPAQuery
     if level > 0:


### PR DESCRIPTION
Implements the `co` (export codebase) command for iOS, mirroring the Android implementation.

Adds `trueseeing/app/cmd/ios/asm.py` with support for:
- Directory export: `co /path [pattern]`
- Tar export: `co /path.tar [pattern]`  
- Gzipped tar export: `co /path.tar.gz [pattern]`
- Force overwrite: `co!` variants

Fixes: #647