### PR TITLE
Scope obfuscation detection to target app package

### DIFF
--- a/trueseeing/sig/android/fingerprint.py
+++ b/trueseeing/sig/android/fingerprint.py
@@ -210,13 +210,18 @@ class ProGuardDetector(SignatureMixin):
 
   async def detect(self) -> None:
     context = self._get_context()
+    package = context.get_package_name()
+    found_in_package = False
     for c in (self._class_name_of(context.source_name_of_disassembled_class(r)) for r in context.disassembled_classes()):
-      m = re.search(r'(?:^|\.)(.)$', c)
-      if m and m.group(1) not in self._whitelist:
-        self._helper.raise_issue(self._helper.build_issue(sigid=self._id, cfd='certain', cvss=self._cvss_true, title='detected obfuscator', info0='ProGuard'))
-        break
+      if c.startswith(f'{package}.'):
+        found_in_package = True
+        m = re.search(r'(?:^|\.)(.)$', c)
+        if m and m.group(1) not in self._whitelist:
+          self._helper.raise_issue(self._helper.build_issue(sigid=self._id, cfd='certain', cvss=self._cvss_true, title='detected obfuscator', info0='ProGuard'))
+          break
     else:
-      self._helper.raise_issue(self._helper.build_issue(sigid=self._id, cvss=self._cvss_false, title='lack of obfuscation'))
+      if found_in_package:
+        self._helper.raise_issue(self._helper.build_issue(sigid=self._id, cvss=self._cvss_false, title='lack of obfuscation'))
 
 class UrlLikeDetector(SignatureMixin):
   _id = 'detect-url'


### PR DESCRIPTION
## Summary
Fixes #621

The obfuscation detector (ProGuardDetector) previously considered ALL classes in the APK when determining if an app was obfuscated. This caused false positives because many libraries ship with obfuscated names.

## Changes
- Now only checks classes under the app's declared package ()
- Reports 'detected obfuscator' if obfuscated class names are found in app package
- Reports 'lack of obfuscation' if app package has classes but none appear obfuscated
- Reports nothing if app package is empty (nothing to evaluate)